### PR TITLE
-i option to print out some metadata

### DIFF
--- a/main.mm
+++ b/main.mm
@@ -479,9 +479,9 @@ int main (int argc, char **argv, char **envp) {
                     printf("Full Version: \"%s\"\n", [appVersion cStringUsingEncoding:NSUTF8StringEncoding]);
                     printf("Short Version: \"%s\"\n", [appShortVersion cStringUsingEncoding:NSUTF8StringEncoding]);
 
-                    return 0;
                 }
             }
+            return 0;
         }
 
 

--- a/main.mm
+++ b/main.mm
@@ -418,6 +418,8 @@ int main (int argc, char **argv, char **envp) {
         }
         if ([op1 isEqualToString:@"-i"] || [op1 isEqualToString:@"-I"]) {
             isGetInfo = YES;
+            for (unsigned int i=2; i<[arguments count]; i++)
+                [identifiers addObject:[arguments objectAtIndex:i]];
         }
 
         if ([op2 isEqualToString:@"-u"]) {
@@ -1026,6 +1028,8 @@ int main (int argc, char **argv, char **envp) {
                     cleanInstall = YES;
                 else if ([p isEqualToString:@"d"])
                     deleteFile = YES;
+                else if ([p isEqualToString:@"i"] || [p isEqualToString:@"I"])
+                    isGetInfo = YES;
                 else if ([p isEqualToString:@"f"])
                     forceInstall = YES;
                 else if ([p isEqualToString:@"h"])

--- a/main.mm
+++ b/main.mm
@@ -44,6 +44,7 @@ static NSString *SystemVersion = nil;
 static int DeviceModel = 0;
 
 static BOOL isUninstall = NO;
+static BOOL isGetInfo = NO;
 static BOOL isListing = NO;
 static BOOL isBackup = NO;
 static BOOL isBackupFull = NO;
@@ -362,7 +363,7 @@ int main (int argc, char **argv, char **envp) {
 
     NSString *executableName = [[arguments objectAtIndex:0] lastPathComponent];
 
-    NSString *helpString = [NSString stringWithFormat:@"Usage: %@ [OPTION]... [FILE]...\n       %@ -{bB} [APP_ID] [-o OUTPUT_PATH]\n       %@ -l\n       %@ -u [APP_ID]...\n\n\nOptions:\n    -a  Show tool about information.\n    -b  Back up application with given identifier to IPA.\n    -B  Back up application with given identifier and its documents and settings to IPA.\n    -c  Perform a clean install.\n        If the application has already been installed, the existing documents and other resources will be cleared.\n        This implements -n automatically.\n    -d  Delete IPA file(s) after installation.\n    -f  Force installation, do not check capabilities and system version.\n        Installed application may not work properly.\n    -h  Display this usage information.\n    -l  List identifiers of all installed App Store applications.\n    -n  Do not restore saved documents and other resources.\n    -o  Output IPA to specified path, or the IPA will be saved under /var/mobile/Documents/.\n    -q  Quiet mode, suppress all normal outputs.\n    -Q  Quieter mode, suppress all outputs including errors.\n    -r  Remove iTunesMetadata.plist after installation.\n    -u  Uninstall application with given identifier(s).", executableName, executableName, executableName, executableName];
+    NSString *helpString = [NSString stringWithFormat:@"Usage: %@ [OPTION]... [FILE]...\n       %@ -{bB} [APP_ID] [-o OUTPUT_PATH]\n       %@ -l\n       %@ -u [APP_ID]...\n\n\nOptions:\n    -a  Show tool about information.\n    -b  Back up application with given identifier to IPA.\n    -B  Back up application with given identifier and its documents and settings to IPA.\n    -c  Perform a clean install.\n        If the application has already been installed, the existing documents and other resources will be cleared.\n        This implements -n automatically.\n    -d  Delete IPA file(s) after installation.\n    -f  Force installation, do not check capabilities and system version.\n        Installed application may not work properly.\n    -h  Display this usage information.\n    -l  List identifiers of all installed App Store applications.\n    -n  Do not restore saved documents and other resources.\n    -o  Output IPA to specified path, or the IPA will be saved under /var/mobile/Documents/.\n    -q  Quiet mode, suppress all normal outputs.\n    -Q  Quieter mode, suppress all outputs including errors.\n    -r  Remove iTunesMetadata.plist after installation.\n    -u  Uninstall application with given identifier(s).\n    -i  Display the meta-data for (a) specified identifier(s).", executableName, executableName, executableName, executableName];
 
     NSDate *today = [NSDate date];
 
@@ -415,6 +416,10 @@ int main (int argc, char **argv, char **envp) {
                     [identifiers addObject:[arguments objectAtIndex:i]];
             }
         }
+        if ([op1 isEqualToString:@"-i"] || [op1 isEqualToString:@"-I"]) {
+            isGetInfo = YES;
+        }
+
         if ([op2 isEqualToString:@"-u"]) {
             if ([op1 isEqualToString:@"-q"]) {
                 isUninstall = YES;
@@ -428,6 +433,57 @@ int main (int argc, char **argv, char **envp) {
                     [identifiers addObject:[arguments objectAtIndex:i]];
             }
         }
+
+        if (isGetInfo)
+        {
+            if ([identifiers count] < 1) {
+                printf("You must specify at least one application identifier.\n");
+                [pool release];
+                return IPA_FAILED;
+            }
+
+            NSArray *installedApps = getInstalledApplications();
+
+            for (unsigned int i=0; i<[identifiers count]; i++) 
+            {
+                if ([installedApps containsObject:[identifiers objectAtIndex:i]]) 
+                {
+                    NSString *identifier = [identifiers objectAtIndex:i];
+                    NSDictionary *installedAppInfo = getInstalledAppInfo(identifier);
+
+                    if (!installedAppInfo) {
+                        if (quietInstall < 2)
+                            printf("Application \"%s\" is not installed.\n", [identifier cStringUsingEncoding:NSUTF8StringEncoding]);
+                        [pool release];
+                        return IPA_FAILED;
+                    } 
+
+                    NSString *appDirPath = [installedAppInfo objectForKey:@"BUNDLE_PATH"];
+                    NSString *appPath = [installedAppInfo objectForKey:@"APP_PATH"];
+                    NSString *dataPath = [installedAppInfo objectForKey:@"DATA_PATH"];
+                    NSString *appName = [installedAppInfo objectForKey:@"NAME"];
+                    NSString *appDisplayName = [installedAppInfo objectForKey:@"DISPLAY_NAME"];
+                    NSString *appVersion = [installedAppInfo objectForKey:@"VERSION"];
+                    NSString *appShortVersion = [installedAppInfo objectForKey:@"SHORT_VERSION"];
+
+                    printf("------------\n");
+                    //Stuff I care for
+                    printf("App Name: \"%s\"\n", [appName cStringUsingEncoding:NSUTF8StringEncoding]);
+                    printf("BundleID: \"%s\"\n", [identifier cStringUsingEncoding:NSUTF8StringEncoding]);
+                    printf("Bundle Directory: \"%s\"\n", [appDirPath cStringUsingEncoding:NSUTF8StringEncoding]);
+                    printf("App Directory: \"%s\"\n", [appPath cStringUsingEncoding:NSUTF8StringEncoding]);
+                    printf("Data Directory: \"%s\"\n", [dataPath cStringUsingEncoding:NSUTF8StringEncoding]);
+
+                    //Stuff im not really caring for
+                    printf("Display Name: \"%s\"\n", [appDisplayName cStringUsingEncoding:NSUTF8StringEncoding]);
+                    printf("Full Version: \"%s\"\n", [appVersion cStringUsingEncoding:NSUTF8StringEncoding]);
+                    printf("Short Version: \"%s\"\n", [appShortVersion cStringUsingEncoding:NSUTF8StringEncoding]);
+
+                    return 0;
+                }
+            }
+        }
+
 
         if (isUninstall) {
             if ([identifiers count] < 1) {


### PR DESCRIPTION
I added an option to print out the metadata for specified bundle ID's. This can be really useful when working with apps frequently and installing/uninstalling frequently.