### PR TITLE
make it work again for iOS11 on Electra

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 export TARGET_CODESIGN_FLAGS="-Ssign.plist"
 export ARCHS = armv7 arm64
-export TARGET=iphone:9.2:4.0
+export TARGET=iphone:11.2:4.0
 GO_EASY_ON_ME=1
 include theos/makefiles/common.mk
 
@@ -28,5 +28,3 @@ before-package::
 	chmod 0755 $(THEOS_STAGING_DIR)/usr/bin/ipainstaller
 	chmod 0644 $(THEOS_STAGING_DIR)/DEBIAN/control
 
-after-package::
-	rm -fr .theos

--- a/sign.plist
+++ b/sign.plist
@@ -1,1 +1,24 @@
-<dict><key>application-identifier</key><string>com.autopear.ipainstaller</string><key>com.apple.private.mobileinstall.allowedSPI</key><array><string>Install</string><string>Browse</string><string>Uninstall</string><string>InstallForLaunchServices</string><string>UninstallForLaunchServices</string></array><key>com.apple.springboard.debugapplications</key><true/><key>get-task-allow</key><true/><key>task_for_pid-allow</key><true/></dict>
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+   <key>application-identifier</key>
+   <string>com.autopear.ipainstaller</string>
+   <key>com.apple.private.mobileinstall.allowedSPI</key>
+   <array>
+      <string>Install</string>
+      <string>Browse</string>
+      <string>Uninstall</string>
+      <string>InstallForLaunchServices</string>
+      <string>UninstallForLaunchServices</string>
+   </array>
+   <key>com.apple.springboard.debugapplications</key>
+   <true/>
+   <key>get-task-allow</key>
+   <true/>
+   <key>task_for_pid-allow</key>
+   <true/>
+   <key>platform-application</key>
+   <true/>
+</dict>
+</plist>


### PR DESCRIPTION
1. use theos 11.2 SDK
2. delete after-package to make `make install` work again.
3. add platform ent and correct the plist xml format. the old one is not complete.